### PR TITLE
Use classifiers to specify the license.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@ from setuptools import setup, find_packages
 setup(name='videotosmi',
       version='0.0.1',
       url='https://github.com/Sotaneum/VideoToSMI',
-      license='MIT',
       author='Donggun LEE',
       author_email='gnyotnu39@gmail.com',
       description='Create a smi file based on the video.',
@@ -11,4 +10,8 @@ setup(name='videotosmi',
       long_description=open('README.md').read(),
       long_description_content_type='text/markdown',
       zip_safe=False,
-      setup_requires=['deepgeo==0.0.1','scipy','opencv-python','matplotlib'])
+      setup_requires=['deepgeo==0.0.1','scipy','opencv-python','matplotlib'],
+      classifiers=[
+          'License :: OSI Approved :: MIT License'
+      ]
+)


### PR DESCRIPTION
Classifiers are a standard way of specifying a license, and make it easy
for automated tools to properly detect the license of the package.

The "license" field should only be used if the license has no
corresponding Trove classifier.